### PR TITLE
Add process error handlers with tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,3 +58,7 @@ npm start
 ## File Storage
 
 Uploaded files are stored in the `uploads` directory and are served statically through the `/uploads` endpoint. 
+
+## Error Handling
+
+This server logs any `unhandledRejection` and `uncaughtException` events. Run `npm test` to confirm the handlers are registered and log errors without crashing.

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,0 +1,4 @@
+module.exports = {
+  preset: 'ts-jest',
+  testEnvironment: 'node',
+};

--- a/src/__tests__/processHandlers.test.js
+++ b/src/__tests__/processHandlers.test.js
@@ -1,0 +1,25 @@
+const server = require('../server').default || require('../server');
+
+afterAll(() => {
+  server.close();
+});
+
+test('logs unhandled rejections', () => {
+  const consoleSpy = jest.spyOn(console, 'error').mockImplementation();
+  process.emit('unhandledRejection', new Error('test'), Promise.resolve());
+  expect(consoleSpy).toHaveBeenCalled();
+  consoleSpy.mockRestore();
+});
+
+test('logs uncaught exceptions and exits', () => {
+  const consoleSpy = jest.spyOn(console, 'error').mockImplementation();
+  const exitSpy = jest.spyOn(process, 'exit').mockImplementation(() => {
+    throw new Error('exit');
+  });
+  expect(() => {
+    process.emit('uncaughtException', new Error('test'));
+  }).toThrow('exit');
+  expect(consoleSpy).toHaveBeenCalled();
+  consoleSpy.mockRestore();
+  exitSpy.mockRestore();
+});

--- a/src/server.ts
+++ b/src/server.ts
@@ -6,6 +6,15 @@ import tshirtRoutes from './routes/tshirt.routes';
 import helpersRoutes from './routes/helpers.routes';
 import { globalLimiter, uploadLimiter } from './middlewares/rateLimiter';
 
+process.on('unhandledRejection', (reason) => {
+  console.error('Unhandled Rejection:', reason);
+});
+
+process.on('uncaughtException', (error) => {
+  console.error('Uncaught Exception:', error);
+  process.exit(1);
+});
+
 const app = express();
 const PORT = process.env.PORT || 4564;
 
@@ -41,6 +50,8 @@ app.get('/health', (req, res) => {
 });
 
 // Start server
-app.listen(PORT, () => {
+const server = app.listen(PORT, () => {
   console.log(`Server is running on port ${PORT}`);
-}); 
+});
+
+export default server;


### PR DESCRIPTION
## Summary
- add global `unhandledRejection` and `uncaughtException` handlers
- export server instance from `src/server.ts`
- document error handling in README
- add jest config
- test handlers with Jest

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687e6db6545c8333ba30fcf3a576a156